### PR TITLE
Add live data to the noise analysis bar chart

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -4,6 +4,8 @@ const API_URL = process.env.REACT_APP_API_URL;
 
 const LOCATIONS_URL = `${API_URL}/devices/locations`;
 
+const ANALYSIS_URL = `${API_URL}/analysis`;
+
 const getLocationMetricsURL = (locationId) => (`${API_URL}/devices/location_metrics/${locationId}`);
 
 const fetchLocations = async () => {
@@ -17,9 +19,14 @@ const fetchLocationMetrics = async (locationId) => {
     return metrics['location_metrics'];
 }
 
+const fetchAnalysis = async () => {
+    return await (await fetch(ANALYSIS_URL)).json();
+}
+
 export {
     LOCATIONS_URL,
     fetchLocations,
     fetchLocationMetrics,
+    fetchAnalysis,
     getLocationMetricsURL
 }

--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -10,11 +10,17 @@ import * as API from "../API";
 const introText = "Select a city to view a summary of the noise levels in this city";
 
 const Analysis = () => {
-    const [isLoading, setIsLoading] = useState(true);
     const [analysis, setAnalysis] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     const fetchAnalysis = async () => {
-        const analysis = await API.fetchAnalysis();
+        const response = await API.fetchAnalysis();
+        const analysis = response.map(({ location: { parish, noise_analysis} }) => ({
+            day_time_average: noise_analysis.day_time_average,
+            day_time_median: noise_analysis.day_time_median,
+            // division: parish ? `${parish}, ${division}` : division,
+            parish: parish
+        }));
         setAnalysis(analysis);
         setIsLoading(false);
     }
@@ -35,8 +41,8 @@ const Analysis = () => {
                 <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
                 <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
                 <AnalysisBarChartsContainer>
-                    <AnalysisBarChart title='Daily Average' metric='average_noise' analysis={analysis}/>
-                    <AnalysisBarChart title='Total Exceedances' metric='total_exceedances' analysis={analysis}/>
+                    <AnalysisBarChart title='Daily Average' metric='day_time_average' analysis={analysis}/>
+                    <AnalysisBarChart title='Daily Median' metric='day_time_median' analysis={analysis}/>
                 </AnalysisBarChartsContainer>
             </AnalysisWrapper>
         </>

--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -4,25 +4,43 @@ import Intro from "./Intro";
 import NoiseStatisticCard from "./NoiseStatisticCard";
 import {AnalysisBarChartsContainer} from "./AnalysisBarChart/AnalysisBarChart.styles";
 import AnalysisBarChart from "./AnalysisBarChart";
+import {useEffect, useState} from "react";
+import * as API from "../API";
 
 const introText = "Select a city to view a summary of the noise levels in this city";
 
-const Analysis = () => (
-    <>
-        <Wrapper>
-            <Intro text={introText}/>
-            <LocationFilter locations={[]}/>
-        </Wrapper>
-        <AnalysisWrapper>
-            <NoiseStatisticCard title={"Quiet Areas"} value={8} noise_range={0}/>
-            <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
-            <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
-            <AnalysisBarChartsContainer>
-                <AnalysisBarChart title='Daily Average' metric='average_noise'/>
-                <AnalysisBarChart title='Total Exceedances' metric='total_exceedances'/>
-            </AnalysisBarChartsContainer>
-        </AnalysisWrapper>
-    </>
-);
+const Analysis = () => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [analysis, setAnalysis] = useState([]);
+
+    const fetchAnalysis = async () => {
+        const analysis = await API.fetchAnalysis();
+        setAnalysis(analysis);
+        setIsLoading(false);
+    }
+
+    useEffect(() => {
+        if (!isLoading) return;
+        fetchAnalysis();
+    }, [isLoading]);
+
+    return (
+        <>
+            <Wrapper>
+                <Intro text={introText}/>
+                <LocationFilter locations={[]}/>
+            </Wrapper>
+            <AnalysisWrapper>
+                <NoiseStatisticCard title={"Quiet Areas"} value={8} noise_range={0}/>
+                <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
+                <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
+                <AnalysisBarChartsContainer>
+                    <AnalysisBarChart title='Daily Average' metric='average_noise' analysis={analysis}/>
+                    <AnalysisBarChart title='Total Exceedances' metric='total_exceedances' analysis={analysis}/>
+                </AnalysisBarChartsContainer>
+            </AnalysisWrapper>
+        </>
+    );
+}
 
 export default Analysis;

--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -18,7 +18,8 @@ const Analysis = () => {
         const analysis = response.map(({ location: { parish, noise_analysis} }) => ({
             day_time_average: noise_analysis.day_time_average,
             day_time_median: noise_analysis.day_time_median,
-            // division: parish ? `${parish}, ${division}` : division,
+            night_time_average: noise_analysis.night_time_average,
+            night_time_median: noise_analysis.night_time_median,
             parish: parish
         }));
         setAnalysis(analysis);
@@ -41,8 +42,14 @@ const Analysis = () => {
                 <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
                 <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
                 <AnalysisBarChartsContainer>
-                    <AnalysisBarChart title='Daily Average' metric='day_time_average' analysis={analysis}/>
-                    <AnalysisBarChart title='Daily Median' metric='day_time_median' analysis={analysis}/>
+                    <AnalysisBarChart title='Noise Analysis (3-day period)'
+                        metric_1='day_time_average'
+                        metric_2='day_time_median'
+                        metric_3='night_time_average'
+                        metric_4='night_time_median'
+                        analysis={analysis}
+                    />
+                    {/* <AnalysisBarChart title='Exceedances' metric='excedances'/> */}
                 </AnalysisBarChartsContainer>
             </AnalysisWrapper>
         </>

--- a/src/components/AnalysisBarChart/index.js
+++ b/src/components/AnalysisBarChart/index.js
@@ -36,7 +36,7 @@ const data = [
    }
 ];
 
-const AnalysisBarChart = ({title, metric}) => (
+const AnalysisBarChart = ({title, metric, analysis}) => (
 	<ChartContainer className='w-full'>
 		<CardTitle>{title}</CardTitle>
 		<LineGraphContainer>

--- a/src/components/AnalysisBarChart/index.js
+++ b/src/components/AnalysisBarChart/index.js
@@ -4,7 +4,7 @@ import {LineGraphContainer} from "../NoiseLevelChart/NoiseLevelChart.styles";
 import {ResponsiveContainer, BarChart, XAxis, YAxis, Tooltip, Legend, Bar} from "recharts";
 
 
-const AnalysisBarChart = ({title, metric, analysis}) => (
+const AnalysisBarChart = ({title, metric_1, metric_2, metric_3, metric_4, analysis}) => (
 	<ChartContainer className='w-full'>
 		<CardTitle>{title}</CardTitle>
 		<LineGraphContainer>
@@ -16,7 +16,10 @@ const AnalysisBarChart = ({title, metric, analysis}) => (
 					<YAxis/>
 					<Tooltip/>
 					<Legend/>
-					<Bar dataKey={metric} fill='#8884d8'/>
+					<Bar dataKey={metric_1} fill='#b8d6d1'/>
+					<Bar dataKey={metric_2} fill='#82a6ad'/>
+					<Bar dataKey={metric_3} fill='#75085c'/>
+					<Bar dataKey={metric_4} fill='#430a4a'/>
 				</BarChart>
 			</ResponsiveContainer>
 		</LineGraphContainer>

--- a/src/components/AnalysisBarChart/index.js
+++ b/src/components/AnalysisBarChart/index.js
@@ -3,38 +3,6 @@ import {CardTitle} from "../NoiseLevelCard/LocationCard.styles";
 import {LineGraphContainer} from "../NoiseLevelChart/NoiseLevelChart.styles";
 import {ResponsiveContainer, BarChart, XAxis, YAxis, Tooltip, Legend, Bar} from "recharts";
 
-const data = [
-   {
-	"city": "Kampala",
-	"division": "Makindye",
-	"average_noise": 65,
-	"total_exceedances": 900
-   },
-   {
-	"city": "Kampala",
-	"division": "Central",
-	"average_noise": 78,
-	"total_exceedances": 650
-   },
-   {
-	"city": "Kampala",
-	"division": "Nakawa",
-	"average_noise": 56,
-	"total_exceedances": 100
-   },
-   {
-	"city": "Kampala",
-	"division": "Kawempe",
-	"average_noise": 45,
-	"total_exceedances": 500
-   },
-   {
-	"city": "Kampala",
-	"division": "Rubaga",
-	"average_noise": 80,
-	"total_exceedances": 432
-   }
-];
 
 const AnalysisBarChart = ({title, metric, analysis}) => (
 	<ChartContainer className='w-full'>
@@ -42,9 +10,9 @@ const AnalysisBarChart = ({title, metric, analysis}) => (
 		<LineGraphContainer>
 			<ResponsiveContainer width='95%' height='80%'>
 				<BarChart
-					data={data}
+					data={analysis}
 				>
-					<XAxis dataKey='division'/>
+					<XAxis dataKey='parish'/>
 					<YAxis/>
 					<Tooltip/>
 					<Legend/>


### PR DESCRIPTION
This PR adds live analysis data (fetched from the backend) to the `Analysis bar chart` on the `Analysis` page

<img width="1393" alt="Screenshot 2022-04-20 at 15 20 11" src="https://user-images.githubusercontent.com/37118361/164229075-8ab63756-5989-4768-8347-b3aa6e605242.png">
