### PR TITLE
Add exceedances graph to analysis page

### DIFF
--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -3,7 +3,9 @@ import LocationFilter from "./LocationFilter";
 import Intro from "./Intro";
 import NoiseStatisticCard from "./NoiseStatisticCard";
 import {AnalysisBarChartsContainer} from "./AnalysisBarChart/AnalysisBarChart.styles";
+import {ExceedanceBarChartsContainer} from "./ExceedanceBarChart/ExceedanceBarChart.styles";
 import AnalysisBarChart from "./AnalysisBarChart";
+import ExceedanceBarChart from "./ExceedanceBarChart";
 import {useEffect, useState} from "react";
 import * as API from "../API";
 
@@ -15,11 +17,13 @@ const Analysis = () => {
 
     const fetchAnalysis = async () => {
         const response = await API.fetchAnalysis();
-        const analysis = response.map(({ location: { parish, noise_analysis} }) => ({
+        const analysis = response.map(({ location: { parish, noise_analysis } }) => ({
             day_time_average: noise_analysis.day_time_average,
             day_time_median: noise_analysis.day_time_median,
             night_time_average: noise_analysis.night_time_average,
             night_time_median: noise_analysis.night_time_median,
+            day_time_exceedances: noise_analysis.day_time_exceedances,
+            night_time_exceedances: noise_analysis.night_time_exceedances,
             parish: parish
         }));
         setAnalysis(analysis);
@@ -42,14 +46,18 @@ const Analysis = () => {
                 <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
                 <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
                 <AnalysisBarChartsContainer>
-                    <AnalysisBarChart title='Noise Analysis (3-day period)'
-                        metric_1='day_time_average'
-                        metric_2='day_time_median'
-                        metric_3='night_time_average'
-                        metric_4='night_time_median'
+                    <AnalysisBarChart title='Noise Analysis (3-day period)' metrics={analysis}
+                        day_time_average='day_time_average'
+                        day_time_median='day_time_median'
+                        night_time_average='night_time_average'
+                        night_time_median='night_time_median'
                         analysis={analysis}
                     />
-                    {/* <AnalysisBarChart title='Exceedances' metric='excedances'/> */}
+                    <ExceedanceBarChart title='Exceedances (3-day period)'
+                        day_time_exceedances='day_time_exceedances'
+                        night_time_exceedances='night_time_exceedances'
+                        analysis={analysis}
+                    />
                 </AnalysisBarChartsContainer>
             </AnalysisWrapper>
         </>

--- a/src/components/ExceedanceBarChart/ExceedanceBarChart.styles.js
+++ b/src/components/ExceedanceBarChart/ExceedanceBarChart.styles.js
@@ -1,0 +1,15 @@
+import tw, {styled} from "twin.macro";
+
+
+export const ExceedanceBarChartsContainer = styled.div`
+    ${tw`
+        grid
+        grid-cols-1
+        gap-4
+        md:col-span-3
+        md:grid-cols-2
+        justify-items-center
+        content-around
+        rounded-lg
+    `}
+`;

--- a/src/components/ExceedanceBarChart/index.js
+++ b/src/components/ExceedanceBarChart/index.js
@@ -4,7 +4,7 @@ import {LineGraphContainer} from "../NoiseLevelChart/NoiseLevelChart.styles";
 import {ResponsiveContainer, BarChart, XAxis, YAxis, Tooltip, Legend, Bar} from "recharts";
 
 
-const AnalysisBarChart = ({title, day_time_average, day_time_median, night_time_average, night_time_median, analysis}) => (
+const ExceedanceBarChart = ({title, day_time_exceedances, night_time_exceedances, analysis}) => (
 	<ChartContainer className='w-full'>
 		<CardTitle>{title}</CardTitle>
 		<LineGraphContainer>
@@ -16,14 +16,12 @@ const AnalysisBarChart = ({title, day_time_average, day_time_median, night_time_
 					<YAxis/>
 					<Tooltip/>
 					<Legend/>
-					<Bar dataKey={day_time_average} fill='#b8d6d1'/>
-					<Bar dataKey={day_time_median} fill='#82a6ad'/>
-					<Bar dataKey={night_time_average} fill='#75085c'/>
-					<Bar dataKey={night_time_median} fill='#430a4a'/>
+					<Bar dataKey={day_time_exceedances} fill='#82a6ad'/>
+					<Bar dataKey={night_time_exceedances} fill='#430a4a'/>
 				</BarChart>
 			</ResponsiveContainer>
 		</LineGraphContainer>
 	</ChartContainer>
 );
 
-export default AnalysisBarChart;
+export default ExceedanceBarChart;


### PR DESCRIPTION
This PR adds a graph to the analysis page showing the number of exceedances for each location:
<br>
<img width="620" alt="Screenshot 2022-05-05 at 16 48 04" src="https://user-images.githubusercontent.com/37118361/166937421-e93e8236-dc5a-41f2-9b4c-336cb8155821.png">
