### PR TITLE
Add live data to summary of noisy vs non-noisy places

### DIFF
--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -8,11 +8,13 @@ import ExceedanceBarChart from "./ExceedanceBarChart";
 import LoaderSpinner from "./LoaderSpinner";
 import {useEffect, useState} from "react";
 import * as API from "../API";
+import {basicNoiseThresholds} from "../utils"
 
 const introText = "Select a city to view a summary of the noise levels in this city";
 
 const Analysis = () => {
     const [analysis, setAnalysis] = useState([]);
+    const [noiseStatistics, setNoiseStatistics] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
 
     const fetchAnalysis = async () => {
@@ -22,9 +24,20 @@ const Analysis = () => {
             night_time_median: noise_analysis.night_time_median,
             day_time_exceedances: noise_analysis.day_time_exceedances,
             night_time_exceedances: noise_analysis.night_time_exceedances,
+            higher_median: Math.max(noise_analysis.day_time_median, noise_analysis.night_time_median),
             parish: parish
         }));
+
+        const noiseStatistics = {
+            quiet: analysis.filter(location => location.higher_median <= basicNoiseThresholds.low).length,
+            moderate: analysis.filter(location => (
+                location.higher_median > basicNoiseThresholds.low && 
+                location.higher_median < basicNoiseThresholds.high)).length,
+            noisy: analysis.filter(location => location.higher_median >= basicNoiseThresholds.high).length
+        }
+
         setAnalysis(analysis);
+        setNoiseStatistics(noiseStatistics)
         setIsLoading(false);
     }
 
@@ -40,9 +53,9 @@ const Analysis = () => {
                 <LocationFilter locations={[]}/>
             </Wrapper>
             <AnalysisWrapper>
-                <NoiseStatisticCard title={"Quiet Areas"} value={8} noise_range={0}/>
-                <NoiseStatisticCard title={"Moderately Noisy Areas"} value={8} noise_range={1}/>
-                <NoiseStatisticCard title={"Very Noisy Areas"} value={8} noise_range={2}/>
+                <NoiseStatisticCard title={"Quiet Areas"} value={noiseStatistics.quiet} noise_range={0}/>
+                <NoiseStatisticCard title={"Moderately Noisy Areas"} value={noiseStatistics.moderate} noise_range={1}/>
+                <NoiseStatisticCard title={"Very Noisy Areas"} value={noiseStatistics.noisy} noise_range={2}/>
                 { isLoading ? <LoaderSpinner span={3}/> :
                     <AnalysisBarChartsContainer>
                         <AnalysisBarChart title='Noise Analysis (3-day period)' metrics={analysis}

--- a/src/components/AnalysisBarChart/AnalysisBarChart.styles.js
+++ b/src/components/AnalysisBarChart/AnalysisBarChart.styles.js
@@ -11,5 +11,6 @@ export const AnalysisBarChartsContainer = styled.div`
         justify-items-center
         content-around
         rounded-lg
+        my-5
     `}
 `;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -6,7 +6,6 @@ import {NoiseLevelKey} from "./NoiseLevelKey";
 import {useEffect, useState} from "react";
 import * as API from "../API";
 import {useSearchParams} from "react-router-dom";
-import {Oval} from "react-loader-spinner";
 import LoaderSpinner from "./LoaderSpinner";
 
 const introText = "Welcome to the Sunbird AI Noise Dashboard. On this page, you can track noise levels across Kampala and Entebbe.";

--- a/src/components/NoiseLevelCard/index.js
+++ b/src/components/NoiseLevelCard/index.js
@@ -6,11 +6,12 @@ import {
     NoiseColorBand,
     GenericNumberCardContainer
 } from "./LocationCard.styles";
+import {basicNoiseThresholds} from "../../utils";
 import {getColorId} from "../NoiseLevelMarker";
 
 const getNoiseLevelDescription = (noiseLevel) => {
-    if (noiseLevel < 55) return "Quiet";
-    if(noiseLevel < 70) return "Moderate";
+    if (noiseLevel < basicNoiseThresholds.low) return "Quiet";
+    if(noiseLevel < basicNoiseThresholds.high) return "Moderate";
     return "Noisy";
 }
 export const GenericNumberCard = ({title, value}) => (

--- a/src/components/NoiseLevelMarker/index.js
+++ b/src/components/NoiseLevelMarker/index.js
@@ -5,6 +5,7 @@ import {
     PopUpContainer,
     NoiseLevelDescription, ViewLocationButton
 } from "./NoiseLevelMarker.styles";
+import {basicNoiseThresholds} from "../../utils";
 import {MdVolumeUp, MdVolumeDown, MdVolumeMute} from "react-icons/md";
 import {divIcon} from "leaflet/dist/leaflet-src.esm";
 import {Marker, Popup} from "react-leaflet";
@@ -14,8 +15,8 @@ const thresholds = [35, 40, 45, 50, 55, 60, 65, 70, 75, 80];
 
 
 const getImage = (noise_level) => {
-    if (noise_level < 55) return (<MdVolumeMute/>)
-    if (noise_level < 70) return (<MdVolumeDown/>)
+    if (noise_level < basicNoiseThresholds.low) return (<MdVolumeMute/>)
+    if (noise_level < basicNoiseThresholds.high) return (<MdVolumeDown/>)
     return (<MdVolumeUp/>)
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,3 +57,8 @@ export const sampleLocations = randomIndices.map((idx) => noiseData[idx]).map((d
         noise_level: index % 5 === 0 ? '80': dataPoint['Noise-Noise_Measurement']
     }
 ));
+
+export const basicNoiseThresholds = {
+    "low": 55,
+    "high": 70
+};


### PR DESCRIPTION
This PR replaces, with live data, the dummy values that appear on the summary of `Quiet` vs `Moderately Noisy` vs `Very Noisy places`, on the `Analysis` page

![Screenshot 2022-06-06 at 11 00 18](https://user-images.githubusercontent.com/37118361/172120363-839b3c2c-d1a8-4b8e-a6e7-f3426867bf31.png)
